### PR TITLE
Enable Shift modifier

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -17,6 +17,7 @@ pub enum Modifier {
     /// so it's simple to implement as levels are deprecated in squeekboard.
     Control,
     Alt,
+    Shift,
     Mod4,
 }
 

--- a/src/data/parsing.rs
+++ b/src/data/parsing.rs
@@ -429,6 +429,9 @@ fn create_action<H: logging::Handler>(
             Modifier::Mod4 => action::Action::ApplyModifier(
                 action::Modifier::Mod4,
             ),
+            Modifier::Shift => action::Action::ApplyModifier(
+                action::Modifier::Shift,
+            ),
             unsupported_modifier => {
                 warning_handler.handle(
                     logging::Level::Bug,

--- a/src/submission.rs
+++ b/src/submission.rs
@@ -295,6 +295,7 @@ impl Submission {
             .map(|(_id, m)| match m {
                 Modifier::Control => Modifiers::CONTROL,
                 Modifier::Alt => Modifiers::MOD1,
+                Modifier::Shift => Modifiers::SHIFT,
                 Modifier::Mod4 => Modifiers::MOD4,
             })
             .fold(Modifiers::empty(), |m, n| m | n);


### PR DESCRIPTION
It works only as a separate button for keyboard shortcuts. Usage in .yaml file: `modifier: "Shift"`

